### PR TITLE
Allow user to set SQS msg timeout by CLI

### DIFF
--- a/dea_conflux/__main__.py
+++ b/dea_conflux/__main__.py
@@ -280,8 +280,10 @@ def run_one(plugin, uuid, shapefile, output, partial, overedge, verbose):
 @click.option('--overwrite/--no-overwrite', default=False,
               help='Rerun scenes that have already been processed.')
 @click.option('-v', '--verbose', count=True)
+@click.option('--timeout', default=15 * 60,
+              help='The duration (in seconds) that the received SQS messages are hidden.')
 def run_from_queue(plugin, queue, shapefile, output, partial,
-                   overwrite, overedge, verbose):
+                   overwrite, overedge, verbose, timeout):
     """
     Run dea-conflux on a scene from a queue.
     """
@@ -329,6 +331,7 @@ def run_from_queue(plugin, queue, shapefile, output, partial,
         response = queue.receive_messages(
             AttributeNames=['All'],
             MaxNumberOfMessages=1,
+            VisibilityTimeout=timeout,
         )
 
         messages = response


### PR DESCRIPTION
Based on AWS API: [https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Queue.receive_messages](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Queue.receive_messages).

Allow the user to pass the AWS SQS message timeout value by CLI. I setup the default timeout to 15 minutes. Wish it will be OK.
