### PR TITLE
make the deadletter queue feature work

### DIFF
--- a/dea_conflux/__main__.py
+++ b/dea_conflux/__main__.py
@@ -427,14 +427,14 @@ def get_ids(product, expressions, verbose, s3):
     help='Visibility timeout in seconds',
     default=18 * 60)
 @click.option(
-    '--retentionperiod', type=str,
+    '--retention-period', type=str,
     help='The length of time, in seconds before retains a message.',
     default=7 * 24 * 3600)
 @click.option(
     '--retries', type=int,
     help='Number of retries',
     default=5)
-def make(name, timeout, retries, retentionperiod):
+def make(name, timeout, retries, retention_period):
     """Make a queue."""
     import boto3
     from botocore.config import Config
@@ -464,7 +464,7 @@ def make(name, timeout, retries, retentionperiod):
         {'deadLetterTargetArn': dl_attrs['Attributes']['QueueArn'],
          'maxReceiveCount': 10})
 
-    attributes['MessageRetentionPeriod'] = retentionperiod
+    attributes['MessageRetentionPeriod'] = retention_period
 
     queue = sqs_client.create_queue(
         QueueName=name,

--- a/dea_conflux/queues.py
+++ b/dea_conflux/queues.py
@@ -19,8 +19,8 @@ def get_queue(queue_name: str):
     queue = sqs.get_queue_by_name(QueueName=queue_name)
     return queue
 
+
 def verify_name(name):
     if not name.startswith('waterbodies_'):
         raise click.ClickException(
             'Waterbodies queues must start with waterbodies_')
-


### PR DESCRIPTION
Setup the devbox environment, then can test the actual features. In this PR:

1. remove the deadletter queue name as input value -> it always be `{normal_queue_name}_deadletter`
2. when job done, delete the normal queue. If the deadletter queue is not emtpy, not delete it.
