### PR TITLE
Allow plugin changes to start docker build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'dea_conflux/**'
+      - 'examples/**'
       - '.github/workflows/push.yml'
       - 'Dockerfile'
 


### PR DESCRIPTION
There are several plug-in files saved under folder `examples`, and their changes will not start a new docker image build. I believe the plugins changes should build a new docker image.