### PR TITLE
Update wit ls5 plugin ref to latest wit book

### DIFF
--- a/examples/wit_ls5.conflux.py
+++ b/examples/wit_ls5.conflux.py
@@ -1,6 +1,3 @@
-import warnings
-
-import numpy as np
 import xarray as xr
 
 product_name = "wit_ls5"
@@ -30,6 +27,19 @@ input_products = {
 }
 
 
+def _tcw(ds: xr.Dataset) -> xr.DataArray:
+    # Tasseled Cap Wetness, Crist 1985
+    ds = ds  # don't normalise!
+    return (
+        0.0315 * ds.nbart_blue
+        + 0.2021 * ds.nbart_green
+        + 0.3102 * ds.nbart_red
+        + 0.1594 * ds.nbart_nir
+        + -0.6806 * ds.nbart_swir_1
+        + -0.6109 * ds.nbart_swir_2
+    )
+
+
 def transform(inputs: xr.Dataset) -> xr.Dataset:
     # organize the datas structure
     # to apply WIT Notebook processing
@@ -39,30 +49,7 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
     wo_ds = xr.merge([inputs[e] for e in input_products["ga_ls_wo_3"]])
     fc_ds = xr.merge([inputs[e] for e in input_products["ga_ls_fc_3"]])
 
-    # missing = set()
-    # for t1, t2 in itertools.product(
-    #    [fc_ds.time.values, wo_ds.time.values, ard_ds.time.values], repeat=2
-    # ):
-    #    missing_ = set(t1) - set(t2)
-    #    missing |= missing_
-
-    # fc_ds = fc_ds.sel(time=[t for t in fc_ds.time.values if t not in missing])
-    # ard_ds = ard_ds.sel(time=[t for t in ard_ds.time.values if t not in missing])
-    # wo_ds = wo_ds.sel(time=[t for t in wo_ds.time.values if t not in missing])
-
-    tcw = calculate_indices(
-        ard_ds,
-        index="TCW",
-        collection="ga_ls_3",
-        normalise=False,
-        drop=False,
-        inplace=False,
-    )
-
-    mask = (wo_ds.water & 0b0110011) == 0
-
-    open_water = wo_ds.water & (1 << 7) > 0
-    wet = tcw.where(~mask).TCW > -350
+    tcw = _tcw(ard_ds)
 
     bs = fc_ds.bs / 100
     pv = fc_ds.pv / 100
@@ -74,6 +61,12 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
     output_rast["bs"] = bs
     output_rast["pv"] = pv
     output_rast["npv"] = npv
+
+    mask = (wo_ds.water & 0b0110011) == 0
+    # not apply poly_raster cause we did it before
+
+    open_water = wo_ds.water & (1 << 7) > 0
+    wet = tcw.where(~mask) > -350
 
     # TCW
     output_rast["wet"] = wet.astype(float)
@@ -87,424 +80,16 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
 
     ds_wit = xr.Dataset(output_rast).where(mask)
 
-    output = {}  # band -> value
-    output["water"] = ds_wit.water.mean(dim=["x", "y"])
-    # TCW comes in where there is no water
-    output["wet"] = ds_wit.wet.mean(dim=["x", "y"])
-    output["bs"] = ds_wit.bs.mean(dim=["x", "y"])
-    output["pv"] = ds_wit.pv.mean(dim=["x", "y"])
-    output["npv"] = ds_wit.npv.mean(dim=["x", "y"])
-
-    print(xr.Dataset(output))
-
-    #pc_missing = (~mask).mean(dim=["x", "y"])
-
-    #ds_wit = ds_wit.where(pc_missing < 0.1)
-
-    #ys = ds_wit[["water", "wet", "bs", "pv", "npv"]].to_array().mean(dim=["x", "y"])
-
-    return xr.Dataset(output)
+    return ds_wit
 
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
-    return inputs
 
+    output = {}  # band -> value
+    output["water"] = inputs.water.mean()
+    output["wet"] = inputs.wet.mean()
+    output["bs"] = inputs.bs.mean()
+    output["pv"] = inputs.pv.mean()
+    output["npv"] = inputs.npv.mean()
 
-def calculate_indices(
-    ds,
-    index=None,
-    collection=None,
-    custom_varname=None,
-    normalise=True,
-    drop=False,
-    inplace=False,
-):
-    """
-    Takes an xarray dataset containing spectral bands, calculates one of
-    a set of remote sensing indices, and adds the resulting array as a
-    new variable in the original dataset.
-
-    Note: by default, this function will create a new copy of the data
-    in memory. This can be a memory-expensive operation, so to avoid
-    this, set `inplace=True`.
-    Last modified: March 2021
-
-    Parameters
-    ----------
-    ds : xarray Dataset
-        A two-dimensional or multi-dimensional array with containing the
-        spectral bands required to calculate the index. These bands are
-        used as inputs to calculate the selected water index.
-    index : str or list of strs
-        A string giving the name of the index to calculate or a list of
-        strings giving the names of the indices to calculate:
-        'AWEI_ns (Automated Water Extraction Index,
-                  no shadows, Feyisa 2014)
-        'AWEI_sh' (Automated Water Extraction Index,
-                   shadows, Feyisa 2014)
-        'BAEI' (Built-Up Area Extraction Index, Bouzekri et al. 2015)
-        'BAI' (Burn Area Index, Martin 1998)
-        'BSI' (Bare Soil Index, Rikimaru et al. 2002)
-        'BUI' (Built-Up Index, He et al. 2010)
-        'CMR' (Clay Minerals Ratio, Drury 1987)
-        'EVI' (Enhanced Vegetation Index, Huete 2002)
-        'FMR' (Ferrous Minerals Ratio, Segal 1982)
-        'IOR' (Iron Oxide Ratio, Segal 1982)
-        'LAI' (Leaf Area Index, Boegh 2002)
-        'MNDWI' (Modified Normalised Difference Water Index, Xu 1996)
-        'MSAVI' (Modified Soil Adjusted Vegetation Index,
-                 Qi et al. 1994)
-        'NBI' (New Built-Up Index, Jieli et al. 2010)
-        'NBR' (Normalised Burn Ratio, Lopez Garcia 1991)
-        'NDBI' (Normalised Difference Built-Up Index, Zha 2003)
-        'NDCI' (Normalised Difference Chlorophyll Index,
-                Mishra & Mishra, 2012)
-        'NDMI' (Normalised Difference Moisture Index, Gao 1996)
-        'NDSI' (Normalised Difference Snow Index, Hall 1995)
-        'NDTI' (Normalise Difference Tillage Index,
-                Van Deventeret et al. 1997)
-        'NDVI' (Normalised Difference Vegetation Index, Rouse 1973)
-        'NDWI' (Normalised Difference Water Index, McFeeters 1996)
-        'SAVI' (Soil Adjusted Vegetation Index, Huete 1988)
-        'TCB' (Tasseled Cap Brightness, Crist 1985)
-        'TCG' (Tasseled Cap Greeness, Crist 1985)
-        'TCW' (Tasseled Cap Wetness, Crist 1985)
-        'TCB_GSO' (Tasseled Cap Brightness, Nedkov 2017)
-        'TCG_GSO' (Tasseled Cap Greeness, Nedkov 2017)
-        'TCW_GSO' (Tasseled Cap Wetness, Nedkov 2017)
-        'WI' (Water Index, Fisher 2016)
-        'kNDVI' (Non-linear Normalised Difference Vegation Index,
-                 Camps-Valls et al. 2021)
-    collection : str
-        An string that tells the function what data collection is
-        being used to calculate the index. This is necessary because
-        different collections use different names for bands covering
-        a similar spectra. Valid options are 'ga_ls_2' (for GA
-        Landsat Collection 2), 'ga_ls_3' (for GA Landsat Collection 3)
-        and 'ga_s2_1' (for GA Sentinel 2 Collection 1).
-    custom_varname : str, optional
-        By default, the original dataset will be returned with
-        a new index variable named after `index` (e.g. 'NDVI'). To
-        specify a custom name instead, you can supply e.g.
-        `custom_varname='custom_name'`. Defaults to None, which uses
-        `index` to name the variable.
-    normalise : bool, optional
-        Some coefficient-based indices (e.g. 'WI', 'BAEI', 'AWEI_ns',
-        'AWEI_sh', 'TCW', 'TCG', 'TCB', 'TCW_GSO', 'TCG_GSO', 'TCB_GSO',
-        'EVI', 'LAI', 'SAVI', 'MSAVI') produce different results if
-        surface reflectance values are not scaled between 0.0 and 1.0
-        prior to calculating the index. Setting `normalise=True` first
-        scales values to a 0.0-1.0 range by dividing by 10000.0.
-        Defaults to True.
-    drop : bool, optional
-        Provides the option to drop the original input data, thus saving
-        space. if drop = True, returns only the index and its values.
-    inplace: bool, optional
-        If `inplace=True`, calculate_indices will modify the original
-        array in-place, adding bands to the input dataset. The default
-        is `inplace=False`, which will instead make a new copy of the
-        original data (and use twice the memory).
-
-    Returns
-    -------
-    ds : xarray Dataset
-        The original xarray Dataset inputted into the function, with a
-        new varible containing the remote sensing index as a DataArray.
-        If drop = True, the new variable/s as DataArrays in the
-        original Dataset.
-    """
-
-    # Set ds equal to a copy of itself in order to prevent the function
-    # from editing the input dataset. This can prevent unexpected
-    # behaviour though it uses twice as much memory.
-    if not inplace:
-        ds = ds.copy(deep=True)
-
-    # Capture input band names in order to drop these if drop=True
-    if drop:
-        bands_to_drop = list(ds.data_vars)
-        print(f"Dropping bands {bands_to_drop}")
-
-    # Dictionary containing remote sensing index band recipes
-    index_dict = {
-        # Normalised Difference Vegation Index, Rouse 1973
-        "NDVI": lambda ds: (ds.nir - ds.red) / (ds.nir + ds.red),
-        # Non-linear Normalised Difference Vegation Index,
-        # Camps-Valls et al. 2021
-        "kNDVI": lambda ds: np.tanh(((ds.nir - ds.red) / (ds.nir + ds.red)) ** 2),
-        # Enhanced Vegetation Index, Huete 2002
-        "EVI": lambda ds: (
-            (2.5 * (ds.nir - ds.red)) / (ds.nir + 6 * ds.red - 7.5 * ds.blue + 1)
-        ),
-        # Leaf Area Index, Boegh 2002
-        "LAI": lambda ds: (
-            3.618
-            * ((2.5 * (ds.nir - ds.red)) / (ds.nir + 6 * ds.red - 7.5 * ds.blue + 1))
-            - 0.118
-        ),
-        # Soil Adjusted Vegetation Index, Huete 1988
-        "SAVI": lambda ds: ((1.5 * (ds.nir - ds.red)) / (ds.nir + ds.red + 0.5)),
-        # Mod. Soil Adjusted Vegetation Index, Qi et al. 1994
-        "MSAVI": lambda ds: (
-            (2 * ds.nir + 1 - ((2 * ds.nir + 1) ** 2 - 8 * (ds.nir - ds.red)) ** 0.5)
-            / 2
-        ),
-        # Normalised Difference Moisture Index, Gao 1996
-        "NDMI": lambda ds: (ds.nir - ds.swir1) / (ds.nir + ds.swir1),
-        # Normalised Burn Ratio, Lopez Garcia 1991
-        "NBR": lambda ds: (ds.nir - ds.swir2) / (ds.nir + ds.swir2),
-        # Burn Area Index, Martin 1998
-        "BAI": lambda ds: (1.0 / ((0.10 - ds.red) ** 2 + (0.06 - ds.nir) ** 2)),
-        # Normalised Difference Chlorophyll Index,
-        # (Mishra & Mishra, 2012)
-        "NDCI": lambda ds: (ds.red_edge_1 - ds.red) / (ds.red_edge_1 + ds.red),
-        # Normalised Difference Snow Index, Hall 1995
-        "NDSI": lambda ds: (ds.green - ds.swir1) / (ds.green + ds.swir1),
-        # Normalised Difference Tillage Index,
-        # Van Deventer et al. 1997
-        "NDTI": lambda ds: (ds.swir1 - ds.swir2) / (ds.swir1 + ds.swir2),
-        # Normalised Difference Water Index, McFeeters 1996
-        "NDWI": lambda ds: (ds.green - ds.nir) / (ds.green + ds.nir),
-        # Modified Normalised Difference Water Index, Xu 2006
-        "MNDWI": lambda ds: (ds.green - ds.swir1) / (ds.green + ds.swir1),
-        # Normalised Difference Built-Up Index, Zha 2003
-        "NDBI": lambda ds: (ds.swir1 - ds.nir) / (ds.swir1 + ds.nir),
-        # Built-Up Index, He et al. 2010
-        "BUI": lambda ds: ((ds.swir1 - ds.nir) / (ds.swir1 + ds.nir))
-        - ((ds.nir - ds.red) / (ds.nir + ds.red)),
-        # Built-up Area Extraction Index, Bouzekri et al. 2015
-        "BAEI": lambda ds: (ds.red + 0.3) / (ds.green + ds.swir1),
-        # New Built-up Index, Jieli et al. 2010
-        "NBI": lambda ds: (ds.swir1 + ds.red) / ds.nir,
-        # Bare Soil Index, Rikimaru et al. 2002
-        "BSI": lambda ds: ((ds.swir1 + ds.red) - (ds.nir + ds.blue))
-        / ((ds.swir1 + ds.red) + (ds.nir + ds.blue)),
-        # Automated Water Extraction Index (no shadows), Feyisa 2014
-        "AWEI_ns": lambda ds: (
-            4 * (ds.green - ds.swir1) - (0.25 * ds.nir * +2.75 * ds.swir2)
-        ),
-        # Automated Water Extraction Index (shadows), Feyisa 2014
-        "AWEI_sh": lambda ds: (
-            ds.blue + 2.5 * ds.green - 1.5 * (ds.nir + ds.swir1) - 0.25 * ds.swir2
-        ),
-        # Water Index, Fisher 2016
-        "WI": lambda ds: (
-            1.7204
-            + 171 * ds.green
-            + 3 * ds.red
-            - 70 * ds.nir
-            - 45 * ds.swir1
-            - 71 * ds.swir2
-        ),
-        # Tasseled Cap Wetness, Crist 1985
-        "TCW": lambda ds: (
-            0.0315 * ds.blue
-            + 0.2021 * ds.green
-            + 0.3102 * ds.red
-            + 0.1594 * ds.nir
-            + -0.6806 * ds.swir1
-            + -0.6109 * ds.swir2
-        ),
-        # Tasseled Cap Greeness, Crist 1985
-        "TCG": lambda ds: (
-            -0.1603 * ds.blue
-            + -0.2819 * ds.green
-            + -0.4934 * ds.red
-            + 0.7940 * ds.nir
-            + -0.0002 * ds.swir1
-            + -0.1446 * ds.swir2
-        ),
-        # Tasseled Cap Brightness, Crist 1985
-        "TCB": lambda ds: (
-            0.2043 * ds.blue
-            + 0.4158 * ds.green
-            + 0.5524 * ds.red
-            + 0.5741 * ds.nir
-            + 0.3124 * ds.swir1
-            + -0.2303 * ds.swir2
-        ),
-        # Tasseled Cap Transformations with Sentinel-2 coefficients
-        # after Nedkov 2017 using Gram-Schmidt orthogonalization (GSO)
-        # Tasseled Cap Wetness, Nedkov 2017
-        "TCW_GSO": lambda ds: (
-            0.0649 * ds.blue
-            + 0.2802 * ds.green
-            + 0.3072 * ds.red
-            + -0.0807 * ds.nir
-            + -0.4064 * ds.swir1
-            + -0.5602 * ds.swir2
-        ),
-        # Tasseled Cap Greeness, Nedkov 2017
-        "TCG_GSO": lambda ds: (
-            -0.0635 * ds.blue
-            + -0.168 * ds.green
-            + -0.348 * ds.red
-            + 0.3895 * ds.nir
-            + -0.4587 * ds.swir1
-            + -0.4064 * ds.swir2
-        ),
-        # Tasseled Cap Brightness, Nedkov 2017
-        "TCB_GSO": lambda ds: (
-            0.0822 * ds.blue
-            + 0.136 * ds.green
-            + 0.2611 * ds.red
-            + 0.5741 * ds.nir
-            + 0.3882 * ds.swir1
-            + 0.1366 * ds.swir2
-        ),
-        # Clay Minerals Ratio, Drury 1987
-        "CMR": lambda ds: (ds.swir1 / ds.swir2),
-        # Ferrous Minerals Ratio, Segal 1982
-        "FMR": lambda ds: (ds.swir1 / ds.nir),
-        # Iron Oxide Ratio, Segal 1982
-        "IOR": lambda ds: (ds.red / ds.blue),
-    }
-
-    # If index supplied is not a list, convert to list. This allows us to
-    # iterate through either multiple or single indices in the loop below
-    indices = index if isinstance(index, list) else [index]
-
-    # calculate for each index in the list of indices supplied (indexes)
-    for index in indices:
-
-        # Select an index function from the dictionary
-        index_func = index_dict.get(str(index))
-
-        # If no index is provided or if no function is returned due to an
-        # invalid option being provided, raise an exception informing user to
-        # choose from the list of valid options
-        if index is None:
-
-            raise ValueError(
-                f"No remote sensing `index` was provided. Please "
-                "refer to the function \ndocumentation for a full "
-                "list of valid options for `index` (e.g. 'NDVI')"
-            )
-
-        elif (
-            index in ["WI", "BAEI", "AWEI_ns", "AWEI_sh", "EVI", "LAI", "SAVI", "MSAVI"]
-            and not normalise
-        ):
-
-            warnings.warn(
-                f"\nA coefficient-based index ('{index}') normally "
-                "applied to surface reflectance values in the \n"
-                "0.0-1.0 range was applied to values in the 0-10000 "
-                "range. This can produce unexpected results; \nif "
-                "required, resolve this by setting `normalise=True`"
-            )
-
-        elif index_func is None:
-
-            raise ValueError(
-                f"The selected index '{index}' is not one of the "
-                "valid remote sensing index options. \nPlease "
-                "refer to the function documentation for a full "
-                "list of valid options for `index`"
-            )
-
-        # Rename bands to a consistent format if depending on what collection
-        # is specified in `collection`. This allows the same index calculations
-        # to be applied to all collections. If no collection was provided,
-        # raise an exception.
-        if collection is None:
-
-            raise ValueError(
-                "'No `collection` was provided. Please specify "
-                "either 'ga_ls_2', 'ga_ls_3' or 'ga_s2_1' \nto "
-                "ensure the function calculates indices using the "
-                "correct spectral bands"
-            )
-
-        elif collection == "ga_ls_3":
-
-            # Dictionary mapping full data names to simpler 'red' alias names
-            bandnames_dict = {
-                "nbart_nir": "nir",
-                "nbart_red": "red",
-                "nbart_green": "green",
-                "nbart_blue": "blue",
-                "nbart_swir_1": "swir1",
-                "nbart_swir_2": "swir2",
-                "nbar_red": "red",
-                "nbar_green": "green",
-                "nbar_blue": "blue",
-                "nbar_nir": "nir",
-                "nbar_swir_1": "swir1",
-                "nbar_swir_2": "swir2",
-            }
-
-            # Rename bands in dataset to use simple names (e.g. 'red')
-            bands_to_rename = {
-                a: b for a, b in bandnames_dict.items() if a in ds.variables
-            }
-
-        elif collection == "ga_s2_1":
-
-            # Dictionary mapping full data names to simpler 'red' alias names
-            bandnames_dict = {
-                "nbart_red": "red",
-                "nbart_green": "green",
-                "nbart_blue": "blue",
-                "nbart_nir_1": "nir",
-                "nbart_red_edge_1": "red_edge_1",
-                "nbart_red_edge_2": "red_edge_2",
-                "nbart_swir_2": "swir1",
-                "nbart_swir_3": "swir2",
-                "nbar_red": "red",
-                "nbar_green": "green",
-                "nbar_blue": "blue",
-                "nbar_nir_1": "nir",
-                "nbar_red_edge_1": "red_edge_1",
-                "nbar_red_edge_2": "red_edge_2",
-                "nbar_swir_2": "swir1",
-                "nbar_swir_3": "swir2",
-            }
-
-            # Rename bands in dataset to use simple names (e.g. 'red')
-            bands_to_rename = {
-                a: b for a, b in bandnames_dict.items() if a in ds.variables
-            }
-
-        elif collection == "ga_ls_2":
-
-            # Pass an empty dict as no bands need renaming
-            bands_to_rename = {}
-
-        # Raise error if no valid collection name is provided:
-        else:
-            raise ValueError(
-                f"'{collection}' is not a valid option for "
-                "`collection`. Please specify either \n"
-                "'ga_ls_2', 'ga_ls_3' or 'ga_s2_1'"
-            )
-
-        # Apply index function
-        try:
-            # If normalised=True, divide data by 10,000 before applying func
-            mult = 10000.0 if normalise else 1.0
-            index_array = index_func(ds.rename(bands_to_rename) / mult)
-        except AttributeError:
-            raise ValueError(
-                f"Please verify that all bands required to "
-                f"compute {index} are present in `ds`. \n"
-                f"These bands may vary depending on the `collection` "
-                f"(e.g. the Landsat `nbart_nir` band \n"
-                f"is equivelent to `nbart_nir_1` for Sentinel 2)"
-            )
-
-        # Add as a new variable in dataset
-        output_band_name = custom_varname if custom_varname else index
-        ds[output_band_name] = index_array
-
-    # Once all indexes are calculated, drop input bands if inplace=False
-    if drop and not inplace:
-        ds = ds.drop(bands_to_drop)
-
-    # If inplace == True, delete bands in-place instead of using drop
-    if drop and inplace:
-        for band_to_drop in bands_to_drop:
-            del ds[band_to_drop]
-
-    # Return input dataset with added water index variable
-    return ds
+    return xr.Dataset(output)

--- a/examples/wit_ls5.conflux.py
+++ b/examples/wit_ls5.conflux.py
@@ -1,3 +1,7 @@
+import itertools
+import warnings
+
+import numpy as np
 import xarray as xr
 
 product_name = "wit_ls5"
@@ -27,59 +31,467 @@ input_products = {
 }
 
 
-def _tcw(ds: xr.Dataset) -> xr.DataArray:
-    # Tasseled Cap Wetness, Crist 1985
-    ds = ds  # don't normalise!
-    return (
-        0.0315 * ds.nbart_blue
-        + 0.2021 * ds.nbart_green
-        + 0.3102 * ds.nbart_red
-        + 0.1594 * ds.nbart_nir
-        + -0.6806 * ds.nbart_swir_1
-        + -0.6109 * ds.nbart_swir_2
-    )
-
-
 def transform(inputs: xr.Dataset) -> xr.Dataset:
-    # Masking
-    cloud = (inputs.water & (1 << 6)) > 0
-    shadow = (inputs.water & (1 << 5)) > 0
-    mask = ~cloud & ~shadow
-    # TCW
-    tcw = (_tcw(inputs) > -350).where(mask)
-    # WO
-    is_wet = inputs.water == 128
-    is_ok = is_wet | (inputs.water == 0)
-    masked_wet = is_wet.where(is_ok)
-    # FC
-    bs = inputs.bs.clip(0, 100) / 100
-    pv = inputs.pv.clip(0, 100) / 100
-    npv = inputs.npv.clip(0, 100) / 100
-    sum_fc = bs + pv + npv
-    masked_bs = (bs / sum_fc).where(mask)
-    masked_pv = (pv / sum_fc).where(mask)
-    masked_npv = (npv / sum_fc).where(mask)
-    return xr.Dataset(
-        {
-            "water": masked_wet,
-            "tcw": tcw,
-            "bs": masked_bs,
-            "pv": masked_pv,
-            "npv": masked_npv,
-        }
+    # organize the datas structure
+    # to apply WIT Notebook processing
+    # approach
+
+    ard_ds = xr.merge([inputs[e] for e in input_products["ga_ls5t_ard_3"]])
+    wo_ds = xr.merge([inputs[e] for e in input_products["ga_ls_wo_3"]])
+    fc_ds = xr.merge([inputs[e] for e in input_products["ga_ls_fc_3"]])
+
+    #missing = set()
+    #for t1, t2 in itertools.product(
+    #    [fc_ds.time.values, wo_ds.time.values, ard_ds.time.values], repeat=2
+    #):
+    #    missing_ = set(t1) - set(t2)
+    #    missing |= missing_
+
+    #fc_ds = fc_ds.sel(time=[t for t in fc_ds.time.values if t not in missing])
+    #ard_ds = ard_ds.sel(time=[t for t in ard_ds.time.values if t not in missing])
+    #wo_ds = wo_ds.sel(time=[t for t in wo_ds.time.values if t not in missing])
+
+    tcw = calculate_indices(
+        ard_ds, index="TCW", collection="ga_ls_3", normalise=False, drop=False, inplace=False
     )
+
+    mask = (wo_ds.water & 0b0110011) == 0
+
+    open_water = wo_ds.water & (1 << 7) > 0
+    wet = tcw.where(~mask).TCW > -350
+
+    bs = fc_ds.bs / 100
+    pv = fc_ds.pv / 100
+    npv = fc_ds.npv / 100
+
+    rast_names = ['pv', 'npv', 'bs', 'wet', 'water']
+    output_rast = {n: xr.zeros_like(ard_ds) for n in rast_names}
+
+    output_rast['bs']= bs
+    output_rast['pv'] = pv
+    output_rast['npv'] = npv
+
+    # TCW
+    output_rast['wet'] = wet.astype(float)
+    for name in rast_names[:3]:
+        output_rast[name].values[wet.values] = 0
+
+
+    output_rast['water'] = open_water.astype(float)
+
+    for name in rast_names[0:4]:
+        output_rast[name].values[open_water.values] = 0
+
+
+    ds_wit = xr.Dataset(output_rast).where(mask)
+
+    pc_missing = (~mask).mean(dim=['x', 'y'])
+
+    ds_wit = ds_wit.where(pc_missing < 0.1)
+
+    return ds_wit
+    
 
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
-    output = {}  # band -> value
-    # water takes priority
-    output["water"] = inputs.water.sum()
-    # TCW comes in where there is no water
-    output["wet"] = inputs.tcw.where(~inputs.water.astype(bool)).sum()
-    # FC everywhere else
-    fc_mask = ~inputs.water.astype(bool) & ~inputs.tcw.astype(bool)
-    output["pv"] = inputs.pv.where(fc_mask).sum()
-    output["npv"] = inputs.npv.where(fc_mask).sum()
-    output["bs"] = inputs.bs.where(fc_mask).sum()
-    output["px_missing"] = inputs.bs.isnull().sum()
-    return xr.Dataset(output)
+    return inputs
+
+
+def calculate_indices(
+    ds,
+    index=None,
+    collection=None,
+    custom_varname=None,
+    normalise=True,
+    drop=False,
+    inplace=False,
+):
+    """
+    Takes an xarray dataset containing spectral bands, calculates one of
+    a set of remote sensing indices, and adds the resulting array as a
+    new variable in the original dataset.
+
+    Note: by default, this function will create a new copy of the data
+    in memory. This can be a memory-expensive operation, so to avoid
+    this, set `inplace=True`.
+    Last modified: March 2021
+
+    Parameters
+    ----------
+    ds : xarray Dataset
+        A two-dimensional or multi-dimensional array with containing the
+        spectral bands required to calculate the index. These bands are
+        used as inputs to calculate the selected water index.
+    index : str or list of strs
+        A string giving the name of the index to calculate or a list of
+        strings giving the names of the indices to calculate:
+        'AWEI_ns (Automated Water Extraction Index,
+                  no shadows, Feyisa 2014)
+        'AWEI_sh' (Automated Water Extraction Index,
+                   shadows, Feyisa 2014)
+        'BAEI' (Built-Up Area Extraction Index, Bouzekri et al. 2015)
+        'BAI' (Burn Area Index, Martin 1998)
+        'BSI' (Bare Soil Index, Rikimaru et al. 2002)
+        'BUI' (Built-Up Index, He et al. 2010)
+        'CMR' (Clay Minerals Ratio, Drury 1987)
+        'EVI' (Enhanced Vegetation Index, Huete 2002)
+        'FMR' (Ferrous Minerals Ratio, Segal 1982)
+        'IOR' (Iron Oxide Ratio, Segal 1982)
+        'LAI' (Leaf Area Index, Boegh 2002)
+        'MNDWI' (Modified Normalised Difference Water Index, Xu 1996)
+        'MSAVI' (Modified Soil Adjusted Vegetation Index,
+                 Qi et al. 1994)
+        'NBI' (New Built-Up Index, Jieli et al. 2010)
+        'NBR' (Normalised Burn Ratio, Lopez Garcia 1991)
+        'NDBI' (Normalised Difference Built-Up Index, Zha 2003)
+        'NDCI' (Normalised Difference Chlorophyll Index,
+                Mishra & Mishra, 2012)
+        'NDMI' (Normalised Difference Moisture Index, Gao 1996)
+        'NDSI' (Normalised Difference Snow Index, Hall 1995)
+        'NDTI' (Normalise Difference Tillage Index,
+                Van Deventeret et al. 1997)
+        'NDVI' (Normalised Difference Vegetation Index, Rouse 1973)
+        'NDWI' (Normalised Difference Water Index, McFeeters 1996)
+        'SAVI' (Soil Adjusted Vegetation Index, Huete 1988)
+        'TCB' (Tasseled Cap Brightness, Crist 1985)
+        'TCG' (Tasseled Cap Greeness, Crist 1985)
+        'TCW' (Tasseled Cap Wetness, Crist 1985)
+        'TCB_GSO' (Tasseled Cap Brightness, Nedkov 2017)
+        'TCG_GSO' (Tasseled Cap Greeness, Nedkov 2017)
+        'TCW_GSO' (Tasseled Cap Wetness, Nedkov 2017)
+        'WI' (Water Index, Fisher 2016)
+        'kNDVI' (Non-linear Normalised Difference Vegation Index,
+                 Camps-Valls et al. 2021)
+    collection : str
+        An string that tells the function what data collection is
+        being used to calculate the index. This is necessary because
+        different collections use different names for bands covering
+        a similar spectra. Valid options are 'ga_ls_2' (for GA
+        Landsat Collection 2), 'ga_ls_3' (for GA Landsat Collection 3)
+        and 'ga_s2_1' (for GA Sentinel 2 Collection 1).
+    custom_varname : str, optional
+        By default, the original dataset will be returned with
+        a new index variable named after `index` (e.g. 'NDVI'). To
+        specify a custom name instead, you can supply e.g.
+        `custom_varname='custom_name'`. Defaults to None, which uses
+        `index` to name the variable.
+    normalise : bool, optional
+        Some coefficient-based indices (e.g. 'WI', 'BAEI', 'AWEI_ns',
+        'AWEI_sh', 'TCW', 'TCG', 'TCB', 'TCW_GSO', 'TCG_GSO', 'TCB_GSO',
+        'EVI', 'LAI', 'SAVI', 'MSAVI') produce different results if
+        surface reflectance values are not scaled between 0.0 and 1.0
+        prior to calculating the index. Setting `normalise=True` first
+        scales values to a 0.0-1.0 range by dividing by 10000.0.
+        Defaults to True.
+    drop : bool, optional
+        Provides the option to drop the original input data, thus saving
+        space. if drop = True, returns only the index and its values.
+    inplace: bool, optional
+        If `inplace=True`, calculate_indices will modify the original
+        array in-place, adding bands to the input dataset. The default
+        is `inplace=False`, which will instead make a new copy of the
+        original data (and use twice the memory).
+
+    Returns
+    -------
+    ds : xarray Dataset
+        The original xarray Dataset inputted into the function, with a
+        new varible containing the remote sensing index as a DataArray.
+        If drop = True, the new variable/s as DataArrays in the
+        original Dataset.
+    """
+
+    # Set ds equal to a copy of itself in order to prevent the function
+    # from editing the input dataset. This can prevent unexpected
+    # behaviour though it uses twice as much memory.
+    if not inplace:
+        ds = ds.copy(deep=True)
+
+    # Capture input band names in order to drop these if drop=True
+    if drop:
+        bands_to_drop = list(ds.data_vars)
+        print(f"Dropping bands {bands_to_drop}")
+
+    # Dictionary containing remote sensing index band recipes
+    index_dict = {
+        # Normalised Difference Vegation Index, Rouse 1973
+        "NDVI": lambda ds: (ds.nir - ds.red) / (ds.nir + ds.red),
+        # Non-linear Normalised Difference Vegation Index,
+        # Camps-Valls et al. 2021
+        "kNDVI": lambda ds: np.tanh(((ds.nir - ds.red) / (ds.nir + ds.red)) ** 2),
+        # Enhanced Vegetation Index, Huete 2002
+        "EVI": lambda ds: (
+            (2.5 * (ds.nir - ds.red)) / (ds.nir + 6 * ds.red - 7.5 * ds.blue + 1)
+        ),
+        # Leaf Area Index, Boegh 2002
+        "LAI": lambda ds: (
+            3.618
+            * ((2.5 * (ds.nir - ds.red)) / (ds.nir + 6 * ds.red - 7.5 * ds.blue + 1))
+            - 0.118
+        ),
+        # Soil Adjusted Vegetation Index, Huete 1988
+        "SAVI": lambda ds: ((1.5 * (ds.nir - ds.red)) / (ds.nir + ds.red + 0.5)),
+        # Mod. Soil Adjusted Vegetation Index, Qi et al. 1994
+        "MSAVI": lambda ds: (
+            (2 * ds.nir + 1 - ((2 * ds.nir + 1) ** 2 - 8 * (ds.nir - ds.red)) ** 0.5)
+            / 2
+        ),
+        # Normalised Difference Moisture Index, Gao 1996
+        "NDMI": lambda ds: (ds.nir - ds.swir1) / (ds.nir + ds.swir1),
+        # Normalised Burn Ratio, Lopez Garcia 1991
+        "NBR": lambda ds: (ds.nir - ds.swir2) / (ds.nir + ds.swir2),
+        # Burn Area Index, Martin 1998
+        "BAI": lambda ds: (1.0 / ((0.10 - ds.red) ** 2 + (0.06 - ds.nir) ** 2)),
+        # Normalised Difference Chlorophyll Index,
+        # (Mishra & Mishra, 2012)
+        "NDCI": lambda ds: (ds.red_edge_1 - ds.red) / (ds.red_edge_1 + ds.red),
+        # Normalised Difference Snow Index, Hall 1995
+        "NDSI": lambda ds: (ds.green - ds.swir1) / (ds.green + ds.swir1),
+        # Normalised Difference Tillage Index,
+        # Van Deventer et al. 1997
+        "NDTI": lambda ds: (ds.swir1 - ds.swir2) / (ds.swir1 + ds.swir2),
+        # Normalised Difference Water Index, McFeeters 1996
+        "NDWI": lambda ds: (ds.green - ds.nir) / (ds.green + ds.nir),
+        # Modified Normalised Difference Water Index, Xu 2006
+        "MNDWI": lambda ds: (ds.green - ds.swir1) / (ds.green + ds.swir1),
+        # Normalised Difference Built-Up Index, Zha 2003
+        "NDBI": lambda ds: (ds.swir1 - ds.nir) / (ds.swir1 + ds.nir),
+        # Built-Up Index, He et al. 2010
+        "BUI": lambda ds: ((ds.swir1 - ds.nir) / (ds.swir1 + ds.nir))
+        - ((ds.nir - ds.red) / (ds.nir + ds.red)),
+        # Built-up Area Extraction Index, Bouzekri et al. 2015
+        "BAEI": lambda ds: (ds.red + 0.3) / (ds.green + ds.swir1),
+        # New Built-up Index, Jieli et al. 2010
+        "NBI": lambda ds: (ds.swir1 + ds.red) / ds.nir,
+        # Bare Soil Index, Rikimaru et al. 2002
+        "BSI": lambda ds: ((ds.swir1 + ds.red) - (ds.nir + ds.blue))
+        / ((ds.swir1 + ds.red) + (ds.nir + ds.blue)),
+        # Automated Water Extraction Index (no shadows), Feyisa 2014
+        "AWEI_ns": lambda ds: (
+            4 * (ds.green - ds.swir1) - (0.25 * ds.nir * +2.75 * ds.swir2)
+        ),
+        # Automated Water Extraction Index (shadows), Feyisa 2014
+        "AWEI_sh": lambda ds: (
+            ds.blue + 2.5 * ds.green - 1.5 * (ds.nir + ds.swir1) - 0.25 * ds.swir2
+        ),
+        # Water Index, Fisher 2016
+        "WI": lambda ds: (
+            1.7204
+            + 171 * ds.green
+            + 3 * ds.red
+            - 70 * ds.nir
+            - 45 * ds.swir1
+            - 71 * ds.swir2
+        ),
+        # Tasseled Cap Wetness, Crist 1985
+        "TCW": lambda ds: (
+            0.0315 * ds.blue
+            + 0.2021 * ds.green
+            + 0.3102 * ds.red
+            + 0.1594 * ds.nir
+            + -0.6806 * ds.swir1
+            + -0.6109 * ds.swir2
+        ),
+        # Tasseled Cap Greeness, Crist 1985
+        "TCG": lambda ds: (
+            -0.1603 * ds.blue
+            + -0.2819 * ds.green
+            + -0.4934 * ds.red
+            + 0.7940 * ds.nir
+            + -0.0002 * ds.swir1
+            + -0.1446 * ds.swir2
+        ),
+        # Tasseled Cap Brightness, Crist 1985
+        "TCB": lambda ds: (
+            0.2043 * ds.blue
+            + 0.4158 * ds.green
+            + 0.5524 * ds.red
+            + 0.5741 * ds.nir
+            + 0.3124 * ds.swir1
+            + -0.2303 * ds.swir2
+        ),
+        # Tasseled Cap Transformations with Sentinel-2 coefficients
+        # after Nedkov 2017 using Gram-Schmidt orthogonalization (GSO)
+        # Tasseled Cap Wetness, Nedkov 2017
+        "TCW_GSO": lambda ds: (
+            0.0649 * ds.blue
+            + 0.2802 * ds.green
+            + 0.3072 * ds.red
+            + -0.0807 * ds.nir
+            + -0.4064 * ds.swir1
+            + -0.5602 * ds.swir2
+        ),
+        # Tasseled Cap Greeness, Nedkov 2017
+        "TCG_GSO": lambda ds: (
+            -0.0635 * ds.blue
+            + -0.168 * ds.green
+            + -0.348 * ds.red
+            + 0.3895 * ds.nir
+            + -0.4587 * ds.swir1
+            + -0.4064 * ds.swir2
+        ),
+        # Tasseled Cap Brightness, Nedkov 2017
+        "TCB_GSO": lambda ds: (
+            0.0822 * ds.blue
+            + 0.136 * ds.green
+            + 0.2611 * ds.red
+            + 0.5741 * ds.nir
+            + 0.3882 * ds.swir1
+            + 0.1366 * ds.swir2
+        ),
+        # Clay Minerals Ratio, Drury 1987
+        "CMR": lambda ds: (ds.swir1 / ds.swir2),
+        # Ferrous Minerals Ratio, Segal 1982
+        "FMR": lambda ds: (ds.swir1 / ds.nir),
+        # Iron Oxide Ratio, Segal 1982
+        "IOR": lambda ds: (ds.red / ds.blue),
+    }
+
+    # If index supplied is not a list, convert to list. This allows us to
+    # iterate through either multiple or single indices in the loop below
+    indices = index if isinstance(index, list) else [index]
+
+    # calculate for each index in the list of indices supplied (indexes)
+    for index in indices:
+
+        # Select an index function from the dictionary
+        index_func = index_dict.get(str(index))
+
+        # If no index is provided or if no function is returned due to an
+        # invalid option being provided, raise an exception informing user to
+        # choose from the list of valid options
+        if index is None:
+
+            raise ValueError(
+                f"No remote sensing `index` was provided. Please "
+                "refer to the function \ndocumentation for a full "
+                "list of valid options for `index` (e.g. 'NDVI')"
+            )
+
+        elif (
+            index in ["WI", "BAEI", "AWEI_ns", "AWEI_sh", "EVI", "LAI", "SAVI", "MSAVI"]
+            and not normalise
+        ):
+
+            warnings.warn(
+                f"\nA coefficient-based index ('{index}') normally "
+                "applied to surface reflectance values in the \n"
+                "0.0-1.0 range was applied to values in the 0-10000 "
+                "range. This can produce unexpected results; \nif "
+                "required, resolve this by setting `normalise=True`"
+            )
+
+        elif index_func is None:
+
+            raise ValueError(
+                f"The selected index '{index}' is not one of the "
+                "valid remote sensing index options. \nPlease "
+                "refer to the function documentation for a full "
+                "list of valid options for `index`"
+            )
+
+        # Rename bands to a consistent format if depending on what collection
+        # is specified in `collection`. This allows the same index calculations
+        # to be applied to all collections. If no collection was provided,
+        # raise an exception.
+        if collection is None:
+
+            raise ValueError(
+                "'No `collection` was provided. Please specify "
+                "either 'ga_ls_2', 'ga_ls_3' or 'ga_s2_1' \nto "
+                "ensure the function calculates indices using the "
+                "correct spectral bands"
+            )
+
+        elif collection == "ga_ls_3":
+
+            # Dictionary mapping full data names to simpler 'red' alias names
+            bandnames_dict = {
+                "nbart_nir": "nir",
+                "nbart_red": "red",
+                "nbart_green": "green",
+                "nbart_blue": "blue",
+                "nbart_swir_1": "swir1",
+                "nbart_swir_2": "swir2",
+                "nbar_red": "red",
+                "nbar_green": "green",
+                "nbar_blue": "blue",
+                "nbar_nir": "nir",
+                "nbar_swir_1": "swir1",
+                "nbar_swir_2": "swir2",
+            }
+
+            # Rename bands in dataset to use simple names (e.g. 'red')
+            bands_to_rename = {
+                a: b for a, b in bandnames_dict.items() if a in ds.variables
+            }
+
+        elif collection == "ga_s2_1":
+
+            # Dictionary mapping full data names to simpler 'red' alias names
+            bandnames_dict = {
+                "nbart_red": "red",
+                "nbart_green": "green",
+                "nbart_blue": "blue",
+                "nbart_nir_1": "nir",
+                "nbart_red_edge_1": "red_edge_1",
+                "nbart_red_edge_2": "red_edge_2",
+                "nbart_swir_2": "swir1",
+                "nbart_swir_3": "swir2",
+                "nbar_red": "red",
+                "nbar_green": "green",
+                "nbar_blue": "blue",
+                "nbar_nir_1": "nir",
+                "nbar_red_edge_1": "red_edge_1",
+                "nbar_red_edge_2": "red_edge_2",
+                "nbar_swir_2": "swir1",
+                "nbar_swir_3": "swir2",
+            }
+
+            # Rename bands in dataset to use simple names (e.g. 'red')
+            bands_to_rename = {
+                a: b for a, b in bandnames_dict.items() if a in ds.variables
+            }
+
+        elif collection == "ga_ls_2":
+
+            # Pass an empty dict as no bands need renaming
+            bands_to_rename = {}
+
+        # Raise error if no valid collection name is provided:
+        else:
+            raise ValueError(
+                f"'{collection}' is not a valid option for "
+                "`collection`. Please specify either \n"
+                "'ga_ls_2', 'ga_ls_3' or 'ga_s2_1'"
+            )
+
+        # Apply index function
+        try:
+            # If normalised=True, divide data by 10,000 before applying func
+            mult = 10000.0 if normalise else 1.0
+            index_array = index_func(ds.rename(bands_to_rename) / mult)
+        except AttributeError:
+            raise ValueError(
+                f"Please verify that all bands required to "
+                f"compute {index} are present in `ds`. \n"
+                f"These bands may vary depending on the `collection` "
+                f"(e.g. the Landsat `nbart_nir` band \n"
+                f"is equivelent to `nbart_nir_1` for Sentinel 2)"
+            )
+
+        # Add as a new variable in dataset
+        output_band_name = custom_varname if custom_varname else index
+        ds[output_band_name] = index_array
+
+    # Once all indexes are calculated, drop input bands if inplace=False
+    if drop and not inplace:
+        ds = ds.drop(bands_to_drop)
+
+    # If inplace == True, delete bands in-place instead of using drop
+    if drop and inplace:
+        for band_to_drop in bands_to_drop:
+            del ds[band_to_drop]
+
+    # Return input dataset with added water index variable
+    return ds

--- a/examples/wit_ls5.conflux.py
+++ b/examples/wit_ls5.conflux.py
@@ -78,12 +78,17 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
     for name in rast_names[0:4]:
         output_rast[name].values[open_water.values] = 0
 
+    # save this unmask then can do 90% check in summarise
+    output_rast["unmask"] = ~mask
+
     ds_wit = xr.Dataset(output_rast).where(mask)
 
     return ds_wit
 
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
+
+    inputs = inputs.where(inputs.unmask.mean() < 0.1)
 
     output = {}  # band -> value
     output["water"] = inputs.water.mean()

--- a/examples/wit_ls5.conflux.py
+++ b/examples/wit_ls5.conflux.py
@@ -88,7 +88,7 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
 
-    inputs = inputs.where(inputs.unmask.mean() < 0.1)
+    inputs = inputs.where(inputs.unmask.values.mean() < 0.1)
 
     output = {}  # band -> value
     output["water"] = inputs.water.mean()

--- a/examples/wit_ls5.conflux.py
+++ b/examples/wit_ls5.conflux.py
@@ -2,7 +2,14 @@ import xarray as xr
 
 product_name = "wit_ls5"
 version = "0.0.1"
-resampling = {"water": "nearest", "*": "bilinear"}
+resampling = {
+    "water": "nearest",
+    "bs": "nearest",
+    "pv": "nearest",
+    "npv": "nearest",
+    "fmask": "nearest",
+    "*": "bilinear",
+}
 output_crs = "EPSG:3577"
 resolution = (-30, 30)
 

--- a/examples/wit_ls7.conflux.py
+++ b/examples/wit_ls7.conflux.py
@@ -2,7 +2,14 @@ import xarray as xr
 
 product_name = "wit_ls7"
 version = "0.0.1"
-resampling = {"water": "nearest", "*": "bilinear"}
+resampling = {
+    "water": "nearest",
+    "bs": "nearest",
+    "pv": "nearest",
+    "npv": "nearest",
+    "fmask": "nearest",
+    "*": "bilinear",
+}
 output_crs = "EPSG:3577"
 resolution = (-30, 30)
 
@@ -34,45 +41,55 @@ def _tcw(ds: xr.Dataset) -> xr.DataArray:
 
 
 def transform(inputs: xr.Dataset) -> xr.Dataset:
-    # Masking
-    cloud = (inputs.water & (1 << 6)) > 0
-    shadow = (inputs.water & (1 << 5)) > 0
-    mask = ~cloud & ~shadow
+    # organize the datas structure
+    # to apply WIT Notebook processing
+    # approach
+
+    ard_ds = xr.merge([inputs[e] for e in input_products["ga_ls7e_ard_3"]])
+    wo_ds = xr.merge([inputs[e] for e in input_products["ga_ls_wo_3"]])
+    fc_ds = xr.merge([inputs[e] for e in input_products["ga_ls_fc_3"]])
+
+    tcw = _tcw(ard_ds)
+
+    bs = fc_ds.bs / 100
+    pv = fc_ds.pv / 100
+    npv = fc_ds.npv / 100
+
+    rast_names = ["pv", "npv", "bs", "wet", "water"]
+    output_rast = {n: xr.zeros_like(ard_ds) for n in rast_names}
+
+    output_rast["bs"] = bs
+    output_rast["pv"] = pv
+    output_rast["npv"] = npv
+
+    mask = (wo_ds.water & 0b0110011) == 0
+    # not apply poly_raster cause we did it before
+
+    open_water = wo_ds.water & (1 << 7) > 0
+    wet = tcw.where(~mask) > -350
+
     # TCW
-    tcw = (_tcw(inputs) > -350).where(mask)
-    # WO
-    is_wet = inputs.water == 128
-    is_ok = is_wet | (inputs.water == 0)
-    masked_wet = is_wet.where(is_ok)
-    # FC
-    bs = inputs.bs.clip(0, 100) / 100
-    pv = inputs.pv.clip(0, 100) / 100
-    npv = inputs.npv.clip(0, 100) / 100
-    sum_fc = bs + pv + npv
-    masked_bs = (bs / sum_fc).where(mask)
-    masked_pv = (pv / sum_fc).where(mask)
-    masked_npv = (npv / sum_fc).where(mask)
-    return xr.Dataset(
-        {
-            "water": masked_wet,
-            "tcw": tcw,
-            "bs": masked_bs,
-            "pv": masked_pv,
-            "npv": masked_npv,
-        }
-    )
+    output_rast["wet"] = wet.astype(float)
+    for name in rast_names[:3]:
+        output_rast[name].values[wet.values] = 0
+
+    output_rast["water"] = open_water.astype(float)
+
+    for name in rast_names[0:4]:
+        output_rast[name].values[open_water.values] = 0
+
+    ds_wit = xr.Dataset(output_rast).where(mask)
+
+    return ds_wit
 
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
+
     output = {}  # band -> value
-    # water takes priority
-    output["water"] = inputs.water.sum()
-    # TCW comes in where there is no water
-    output["wet"] = inputs.tcw.where(~inputs.water.astype(bool)).sum()
-    # FC everywhere else
-    fc_mask = ~inputs.water.astype(bool) & ~inputs.tcw.astype(bool)
-    output["pv"] = inputs.pv.where(fc_mask).sum()
-    output["npv"] = inputs.npv.where(fc_mask).sum()
-    output["bs"] = inputs.bs.where(fc_mask).sum()
-    output["px_missing"] = inputs.bs.isnull().sum()
+    output["water"] = inputs.water.mean()
+    output["wet"] = inputs.wet.mean()
+    output["bs"] = inputs.bs.mean()
+    output["pv"] = inputs.pv.mean()
+    output["npv"] = inputs.npv.mean()
+
     return xr.Dataset(output)

--- a/examples/wit_ls7.conflux.py
+++ b/examples/wit_ls7.conflux.py
@@ -1,3 +1,4 @@
+import numpy as np
 import xarray as xr
 
 product_name = "wit_ls7"
@@ -78,8 +79,8 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
     for name in rast_names[0:4]:
         output_rast[name].values[open_water.values] = 0
 
-    # save this unmask then can do 90% check in summarise
-    output_rast["unmask"] = ~mask
+    # save this mask then can do 90% check in summarise
+    output_rast["mask"] = (mask).astype(int)
 
     ds_wit = xr.Dataset(output_rast).where(mask)
 
@@ -88,7 +89,8 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
 
-    inputs = inputs.where(inputs.unmask.values.mean() < 0.1)
+    pc_missing = 1 - np.nansum(inputs.mask.values) / len(inputs.mask.values)
+    inputs = inputs.where(pc_missing < 0.1)
 
     output = {}  # band -> value
     output["water"] = inputs.water.mean()
@@ -96,5 +98,6 @@ def summarise(inputs: xr.Dataset) -> xr.Dataset:
     output["bs"] = inputs.bs.mean()
     output["pv"] = inputs.pv.mean()
     output["npv"] = inputs.npv.mean()
+    output["pc_missing"] = pc_missing
 
     return xr.Dataset(output)

--- a/examples/wit_ls7.conflux.py
+++ b/examples/wit_ls7.conflux.py
@@ -78,12 +78,17 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
     for name in rast_names[0:4]:
         output_rast[name].values[open_water.values] = 0
 
+    # save this unmask then can do 90% check in summarise
+    output_rast["unmask"] = ~mask
+
     ds_wit = xr.Dataset(output_rast).where(mask)
 
     return ds_wit
 
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
+
+    inputs = inputs.where(inputs.unmask.mean() < 0.1)
 
     output = {}  # band -> value
     output["water"] = inputs.water.mean()

--- a/examples/wit_ls7.conflux.py
+++ b/examples/wit_ls7.conflux.py
@@ -88,7 +88,7 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
 
-    inputs = inputs.where(inputs.unmask.mean() < 0.1)
+    inputs = inputs.where(inputs.unmask.values.mean() < 0.1)
 
     output = {}  # band -> value
     output["water"] = inputs.water.mean()

--- a/examples/wit_ls8.conflux.py
+++ b/examples/wit_ls8.conflux.py
@@ -78,12 +78,16 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
     for name in rast_names[0:4]:
         output_rast[name].values[open_water.values] = 0
 
+    output_rast["unmask"] = ~mask
+
     ds_wit = xr.Dataset(output_rast).where(mask)
 
     return ds_wit
 
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
+
+    inputs = inputs.where(inputs.unmask.mean() < 0.1)
 
     output = {}  # band -> value
     output["water"] = inputs.water.mean()

--- a/examples/wit_ls8.conflux.py
+++ b/examples/wit_ls8.conflux.py
@@ -1,3 +1,4 @@
+import numpy as np
 import xarray as xr
 
 product_name = "wit_ls8"
@@ -78,7 +79,8 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
     for name in rast_names[0:4]:
         output_rast[name].values[open_water.values] = 0
 
-    output_rast["unmask"] = ~mask
+    # save this mask then can do 90% check in summarise
+    output_rast["mask"] = (mask).astype(int)
 
     ds_wit = xr.Dataset(output_rast).where(mask)
 
@@ -87,7 +89,8 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
 
-    inputs = inputs.where(inputs.unmask.values.mean() < 0.1)
+    pc_missing = 1 - np.nansum(inputs.mask.values) / len(inputs.mask.values)
+    inputs = inputs.where(pc_missing < 0.1)
 
     output = {}  # band -> value
     output["water"] = inputs.water.mean()
@@ -95,5 +98,6 @@ def summarise(inputs: xr.Dataset) -> xr.Dataset:
     output["bs"] = inputs.bs.mean()
     output["pv"] = inputs.pv.mean()
     output["npv"] = inputs.npv.mean()
+    output["pc_missing"] = pc_missing
 
     return xr.Dataset(output)

--- a/examples/wit_ls8.conflux.py
+++ b/examples/wit_ls8.conflux.py
@@ -87,7 +87,7 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
 
 def summarise(inputs: xr.Dataset) -> xr.Dataset:
 
-    inputs = inputs.where(inputs.unmask.mean() < 0.1)
+    inputs = inputs.where(inputs.unmask.values.mean() < 0.1)
 
     output = {}  # band -> value
     output["water"] = inputs.water.mean()


### PR DESCRIPTION
Hi, @BexDunn and @MatthewJA . How are you. In this PR, I almost just copy paste from [notebook](https://github.com/GeoscienceAustralia/dea-notebooks/blob/6905d4f4a494825ede549c8d7942a7cdaa6046f0/Scientific_workflows/Wetlands_Insight_Tool/WITBook.ipynb) codes to WIT plugins.

There are several changes:
1. In the WIT plugin transform section, there is only one timestamp in Dataset, so there is no need to do the time missing check
2. Use the `_tcw()` to replace the `calculated_indices()`: I test it, and their output are same.
3. There is no polygon mask filter in plugin, becuase it happen in `drill.py`

I only do the single-scene test in EKS environment by CMD: `dea-conflux run-one --uuid 5514b137-737d-425e-8e49-c252bc9e5241 --plugin examples/wit_ls5.conflux.py -o s3://dea-public-data-dev/projects/WIT/pod_run_test -s s3://dea-public-data-dev/projects/WIT/test_shp/ramsar_wetlands_3577_perth-index_42-only.shp`. Once we merge this PR, I can have the new docker image from develop branch and test it on Airflow environment.