### PR TITLE
Allow queue starts with wit

### DIFF
--- a/dea_conflux/queues.py
+++ b/dea_conflux/queues.py
@@ -21,8 +21,8 @@ def get_queue(queue_name: str):
 
 
 def verify_name(name):
-    if not name.startswith("waterbodies_"):
-        raise click.ClickException("Waterbodies queues must start with waterbodies_")
+    if (not name.startswith("waterbodies_")) and (not name.startswith("wit_")):
+        raise click.ClickException("DEA conflux queues must start with waterbodies_ or wit_")
 
 
 def move_to_deadletter_queue(dl_queue_name, message_body):


### PR DESCRIPTION
We already added the WIT relative AWS resource in GA system. There is a WIT AWS IAM user, which allow to modify AWS SQS queue name starts with `wit_`. Therefore, we modify the API to allow the queue start with `wit_`.