### PR TITLE
Add a feature to not/always save empty dataframe as pq file

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -44,7 +44,6 @@ py==1.11.0
 pyarrow==6.0.1
 pycparser==2.21
 pyparsing==3.0.6
-pyproj==3.2.1
 pyrsistent==0.18.0
 pytest==6.2.5
 python-dateutil==2.8.2

--- a/dea_conflux/__main__.py
+++ b/dea_conflux/__main__.py
@@ -241,8 +241,13 @@ def main():
     default=True,
     help="Include data from over the scene boundary.",
 )
+@click.option(
+    "--dump-empty-dataframe/--not-dump-empty-dataframe", 
+    default=True,
+    help="Not matter DataFrame is empty or not, always as it as Parquet file.",
+)
 @click.option("-v", "--verbose", count=True)
-def run_one(plugin, uuid, shapefile, output, partial, overedge, verbose):
+def run_one(plugin, uuid, shapefile, output, partial, overedge, dump_empty_dataframe, verbose):
     """
     Run dea-conflux on one scene.
     """
@@ -296,10 +301,14 @@ def run_one(plugin, uuid, shapefile, output, partial, overedge, verbose):
             overedge=overedge,
             dc=dc,
         )
-        centre_date = dc.index.datasets.get(uuid).center_time
-        dea_conflux.io.write_table(
-            plugin.product_name, uuid, centre_date, table, output
-        )
+
+        # if always dump drill result, or drill result is not empty,
+        # dump that dataframe as PQ file
+        if (dump_empty_dataframe) or (not table.empty):
+            centre_date = dc.index.datasets.get(uuid).center_time
+            dea_conflux.io.write_table(
+                plugin.product_name, uuid, centre_date, table, output
+            )
     except KeyError as keyerr:
         logger.error(f"Found {uuid} has KeyError: {str(keyerr)}")
     except TypeError as typeerr:

--- a/dea_conflux/queues.py
+++ b/dea_conflux/queues.py
@@ -22,7 +22,9 @@ def get_queue(queue_name: str):
 
 def verify_name(name):
     if (not name.startswith("waterbodies_")) and (not name.startswith("wit_")):
-        raise click.ClickException("DEA conflux queues must start with waterbodies_ or wit_")
+        raise click.ClickException(
+            "DEA conflux queues must start with waterbodies_ or wit_"
+        )
 
 
 def move_to_deadletter_queue(dl_queue_name, message_body):

--- a/index_tiles.sh
+++ b/index_tiles.sh
@@ -1,15 +1,12 @@
 # Index one WOfS and FC tile (Belconnen)
-# WOfLs
-# s3-to-dc 's3://dea-public-data/WOfS/WOFLs/v2.1.5/combined/x_15/y_-40/2000/02/**/*.yaml' --no-sign-request --skip-lineage 'wofs_albers'
 # C3 ARD
 s3-to-dc 's3://dea-public-data/baseline/ga_ls7e_ard_3/090/084/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls7e_ard_3'
 s3-to-dc 's3://dea-public-data/baseline/ga_ls7e_ard_3/090/085/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls7e_ard_3'
 # C3 WO
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/091/085/2000/02/09/*.json' --stac --no-sign-request --skip-lineage 'ga_ls_wo_3'
+s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/091/084/2000/02/09/*.json' --stac --no-sign-request --skip-lineage 'ga_ls_wo_3'
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/090/084/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls_wo_3'
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/090/085/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls_wo_3'
 # C3 FC
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_fc_3/2-5-0/090/084/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls_fc_3'
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_fc_3/2-5-0/090/085/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls_fc_3'
-# FC
-# s3-to-dc 's3://dea-public-data/fractional-cover/fc/v2.2.1/ls7/x_15/y_-40/2000/02/**/*.yaml' --no-sign-request --skip-lineage 'ls7_fc_albers'

--- a/index_tiles.sh
+++ b/index_tiles.sh
@@ -3,7 +3,7 @@
 # s3-to-dc 's3://dea-public-data/WOfS/WOFLs/v2.1.5/combined/x_15/y_-40/2000/02/**/*.yaml' --no-sign-request --skip-lineage 'wofs_albers'
 # C3 ARD
 s3-to-dc 's3://dea-public-data/baseline/ga_ls7e_ard_3/090/084/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls7e_ard_3'
-s3-to-dc 's3://dea-public-data/baseline/ga_ls7e_ard_3/090/085/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls7e_ard_3' 
+s3-to-dc 's3://dea-public-data/baseline/ga_ls7e_ard_3/090/085/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls7e_ard_3'
 # C3 WO
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/091/085/2000/02/09/*.json' --stac --no-sign-request --skip-lineage 'ga_ls_wo_3'
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/090/084/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls_wo_3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 datacube==1.8.6
 psycopg2-binary==2.9.2
+pyproj==3.2.1
 python-geohash==0.8.5
 s3fs==0.4.2
 SQLAlchemy>=1.4.27

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,16 +5,16 @@
 - use `docker-compose build` from the root directory
 - to launch, `docker-compose up -d` starts the docker
 - you should have three containers running. You can check   this by running `docker-compose ps`
-- from outside docker, run the shell script `tests/setup_test_datacube.sh` to set up the test datacube. This initialises the docker container datacube, downloads datasets required for testing and indexes them into this datacube. 
+- from outside docker, run the shell script `tests/setup_test_datacube.sh` to set up the test datacube. This initialises the docker container datacube, downloads datasets required for testing and indexes them into this datacube.
 - this process sets up a datacube and an environment to run conflux.
 - now you can run tests in docker <img src="https://emojis.slackmojis.com/emojis/images/1507772920/3024/penguin_dance.gif?1507772920" alt="dancing penguin" width="16"/>
-- If the docker container needs rebuilding run `docker-compose build` 
+- If the docker container needs rebuilding run `docker-compose build`
 - Once you are done with testing, you can shut down the containers with `docker-compose down`
 
 
 ## Running tests in Docker
-- Once containers are up, you can run testing with the command `docker-compose exec conflux pytest` 
-- If you want to run the tests interactively and have access to the interactive debugger, 
+- Once containers are up, you can run testing with the command `docker-compose exec conflux pytest`
+- If you want to run the tests interactively and have access to the interactive debugger,
   Execute bash within the docker container conflux `docker-compose exec conflux bash` and then run `pytest` from the code directory:
 
 ```bash
@@ -28,7 +28,7 @@ The tests assume that `dea-conflux` is installed. To install, follow the instruc
 jovyan@jupyter:dea-conflux$ pip install -e .
 ```
 
-Remember the dot (.)! 
+Remember the dot (.)!
 
 To run tests, use `pytest` from the dea-conflux repository root, in the terminal:
 

--- a/tests/setup_test_datacube.sh
+++ b/tests/setup_test_datacube.sh
@@ -17,7 +17,7 @@ cat > index_tiles.sh <<EOF
 # Index one WOfS and FC tile (Belconnen)
 # C3 ARD
 s3-to-dc 's3://dea-public-data/baseline/ga_ls7e_ard_3/090/084/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls7e_ard_3'
-s3-to-dc 's3://dea-public-data/baseline/ga_ls7e_ard_3/090/085/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls7e_ard_3' 
+s3-to-dc 's3://dea-public-data/baseline/ga_ls7e_ard_3/090/085/2000/02/02/*.json' --stac --no-sign-request --skip-lineage 'ga_ls7e_ard_3'
 # C3 WO
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/091/085/2000/02/09/*.json' --stac --no-sign-request --skip-lineage 'ga_ls_wo_3'
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/091/084/2000/02/09/*.json' --stac --no-sign-request --skip-lineage 'ga_ls_wo_3'


### PR DESCRIPTION
We found there are many fully empty parquet files in WIT running result (because `No polygons found in some scenes`, which is the expected result). However, these empty PQ files bring the extra workload to WIT stack method: https://github.com/GeoscienceAustralia/dea-conflux/blob/main/dea_conflux/stack.py#L128-L136 (because we use `aws s3 ls` to query output folder).

Therefore, we add a option: `--dump-empty-dataframe/--not-dump-empty-dataframe`. If we select `--dump-empty-dataframe` (default option), it will always dump the PQ file (not matter it is empty or not). If we select `--not-dump-empty-dataframe`, and dataframe is empty, it will not dump relative PQ file.

I also use local enviornment to test (CMD is:
`dea-conflux run-one --uuid cbe16b72-5ba4-40ef-84ce-72d703c341a0 --plugin examples/wit_ls5.conflux.py --overedge --partial --shapefile s3://dea-public-data-dev/projects/WIT/test_shp/C2_v4_NSW_only.shp --output test_folder` to test three cases:

1. not pass anything about `dumpy-empty-dataframe` (should use dump-empty-dataframe as dafault option)
2. pass `--not-dump-empty-dataframe`
3. pass `--dump-empty-dataframe`

All three works as expected.