### PR TITLE
Add flag to stack CLI to remove/not remove timeseries duplicated data in CSV

### DIFF
--- a/dea_conflux/__main__.py
+++ b/dea_conflux/__main__.py
@@ -1080,7 +1080,12 @@ def package_delivery(csv_path, output, precision, verbose):
     default=1,
     help="Number of chunks after split overall waterbodies ID list.",
 )
-def db_to_csv(output, verbose, jobs, index_num, split_num):
+@click.option(
+    "--remove-duplicated-data/--no-remove-duplicated-data",
+    default=True,
+    help="Remove timeseries duplicated data if applicable. Default True",
+)
+def db_to_csv(output, verbose, jobs, index_num, split_num, remove_duplicated_data):
     """Output Waterbodies-style CSVs from a database."""
     logging_setup(verbose)
 
@@ -1090,6 +1095,7 @@ def db_to_csv(output, verbose, jobs, index_num, split_num):
         n_workers=jobs,
         index_num=index_num,
         split_num=split_num,
+        remove_duplicated_data=remove_duplicated_data,
     )
 
 

--- a/dea_conflux/__main__.py
+++ b/dea_conflux/__main__.py
@@ -975,7 +975,12 @@ def push_to_queue(txt, queue, verbose):
 @click.option(
     "--drop/--no-drop", default=False, help="Drop database if applicable. Default False"
 )
-def stack(parquet_path, output, pattern, mode, verbose, drop):
+@click.option(
+    "--remove-duplicated-data/--no-remove-duplicated-data",
+    default=True,
+    help="Remove timeseries duplicated data if applicable. Default True",
+)
+def stack(parquet_path, output, pattern, mode, verbose, drop, remove_duplicated_data):
     """
     Stack outputs of dea-conflux into other formats.
     """
@@ -991,8 +996,10 @@ def stack(parquet_path, output, pattern, mode, verbose, drop):
     kwargs = {}
     if mode == "waterbodies" or mode == "wit_tooling":
         kwargs["output_dir"] = output
+        kwargs["remove_duplicated_data"] = remove_duplicated_data
     elif mode == "waterbodies_db":
         kwargs["drop"] = drop
+        kwargs["remove_duplicated_data"] = remove_duplicated_data
 
     dea_conflux.stack.stack(
         parquet_path,

--- a/dea_conflux/stack.py
+++ b/dea_conflux/stack.py
@@ -182,7 +182,11 @@ def remove_timeseries_with_duplicated(df: pd.DataFrame) -> pd.DataFrame:
         The polygon base timeseries result without duplicated data.
     """
 
-    df = df.assign(DAY=[e.split("T")[0] for e in df["date"]])
+    if "date" not in df.columns:
+        # In the WaterBody PQ to CSV use case, the index is date
+        df = df.assign(DAY=[e.split("T")[0] for e in df.index])
+    else:
+        df = df.assign(DAY=[e.split("T")[0] for e in df["date"]])
 
     df = df.sort_values(["DAY", "pc_missing"], ascending=True)
     # The pc_missing the less the better, so we only keep the first one
@@ -613,7 +617,7 @@ def stack_waterbodies_db_to_csv(
             print(out_path + "/" + wb.wb_name[:4] + "/" + wb.wb_name + ".csv")
         # The pc_missing should not in final WaterBodies result
         df.drop(columns=["pc_missing"], inplace=True)
-        
+
         df.to_csv(
             out_path + "/" + wb.wb_name[:4] + "/" + wb.wb_name + ".csv",
             header=True,

--- a/dea_conflux/stack.py
+++ b/dea_conflux/stack.py
@@ -182,15 +182,7 @@ def remove_timeseries_with_duplicated(df: pd.DataFrame) -> pd.DataFrame:
         The polygon base timeseries result without duplicated data.
     """
 
-    df_columns = ["pc_missing", "date"]
-
-    if len([e for e in list(df.columns) if e in df_columns]) == len(df_columns):
-        df = df.assign(DAY=[e.split("T")[0] for e in df["date"]])
-    elif "pc_missing" in list(df.columns):
-        df = df.assign(DAY=[e.split("T")[0] for e in df.index])
-    else:
-        # If the DataFrame does not have pc_missing, stop processing
-        raise NotImplementedError
+    df = df.assign(DAY=[e.split("T")[0] for e in df["date"]])
 
     df = df.sort_values(["DAY", "pc_missing"], ascending=True)
     # The pc_missing the less the better, so we only keep the first one
@@ -610,13 +602,17 @@ def stack_waterbodies_db_to_csv(
                 "date": stack_format_date(ob.date),
                 "pc_wet": round(ob.pc_wet * 100, 2),
                 "px_wet": ob.px_wet,
+                "pc_missing": ob.pc_missing,
             }
             for ob in obs
         ]
 
-        df = pd.DataFrame(rows, columns=["date", "pc_wet", "px_wet"])
+        df = pd.DataFrame(rows, columns=["date", "pc_wet", "px_wet", "pc_missing"])
         if remove_duplicated_data:
             df = remove_timeseries_with_duplicated(df)
+            print(out_path + "/" + wb.wb_name[:4] + "/" + wb.wb_name + ".csv")
+        # The pc_missing should not in final WaterBodies result
+        df = df.drop(columns=["pc_missing"])
         df.to_csv(
             out_path + "/" + wb.wb_name[:4] + "/" + wb.wb_name + ".csv",
             header=True,

--- a/dea_conflux/stack.py
+++ b/dea_conflux/stack.py
@@ -612,7 +612,8 @@ def stack_waterbodies_db_to_csv(
             df = remove_timeseries_with_duplicated(df)
             print(out_path + "/" + wb.wb_name[:4] + "/" + wb.wb_name + ".csv")
         # The pc_missing should not in final WaterBodies result
-        df = df.drop(columns=["pc_missing"])
+        df.drop(columns=["pc_missing"], inplace=True)
+        
         df.to_csv(
             out_path + "/" + wb.wb_name[:4] + "/" + wb.wb_name + ".csv",
             header=True,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -301,6 +301,36 @@ def test_waterbodies_stack(run_main, tmp_path):
     )
     print(stack_result)
 
+    stack_result = run_main(
+        [
+            "stack",
+            "--parquet-path",
+            TEST_WB_PQ_DATA,
+            "--output",
+            str(tmp_path / "testout"),
+            "--mode",
+            "waterbodies",
+            "--remove-duplicated-data",
+        ],
+        expect_success=True,
+    )
+    print(stack_result)
+
+    stack_result = run_main(
+        [
+            "stack",
+            "--parquet-path",
+            TEST_WB_PQ_DATA,
+            "--output",
+            str(tmp_path / "testout"),
+            "--mode",
+            "waterbodies",
+            "--no-remove-duplicated-data",
+        ],
+        expect_success=True,
+    )
+    print(stack_result)
+
 
 def test_wit_package(run_main, tmp_path):
     stack_result = run_main(


### PR DESCRIPTION
Add a new flag: `remove_duplicated_data` which can removed the timeseries duplicated data in CSV. In this change, the assumption of the polygon based result (CSV format) is that same day will only have `ONE` result. Therefore, we sort the raw result by `datetime-day` (comes from date column) and `pc_missing`, and keep the first recordings of each day (the lowest `pc_missing` result).

Before:

![Untitled (1)](https://user-images.githubusercontent.com/6810600/178909778-5bbd8db0-ef1b-4bd9-968d-ce61062a29bb.png)

After:
![Untitled (2)](https://user-images.githubusercontent.com/6810600/178909815-85e6f87a-0816-44b3-9a10-d4dcf89aa49e.png)
