### PR TITLE
Change the WIT stack pool size to fix number

### DIFF
--- a/dea_conflux/stack.py
+++ b/dea_conflux/stack.py
@@ -378,9 +378,7 @@ def stack_wit_tooling(
     logger.info("Reading...")
 
     with tqdm(total=len(paths)) as bar:
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=multiprocessing.cpu_count() * 16
-        ) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
             wit_df_list = []
             futures = {executor.submit(load_pq_file, path): path for path in paths}
             for future in concurrent.futures.as_completed(futures):


### PR DESCRIPTION
We used to use cpu_count * 16 to generate the pool_size. But the `multiprocessing.cpu_count()` is a EC2 instance level value, but we are using K8s pod to run the Stack step.

Consider it is a internal service, let us use a fix number for now.