### PR TITLE
Fix a parameter typo in index API

### DIFF
--- a/dea_conflux/stack.py
+++ b/dea_conflux/stack.py
@@ -279,7 +279,7 @@ def save_df_as_csv(single_polygon_df, feature_id, outpath, remove_duplicated_dat
     if not outpath.startswith("s3://"):
         os.makedirs(Path(filename).parent, exist_ok=True)
     with fsspec.open(filename, "w") as f:
-        single_polygon_df.to_csv(f, index_label=False)
+        single_polygon_df.to_csv(f, index=False)
     return filename
 
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -103,7 +103,7 @@ def test_wit_stacking(tmp_path):
     assert len(csv) == 1
     assert (
         len(csv.columns) == 11
-    )  # feature_id, bs, npv, pc_missing, pv, water, wet, norm_pv, norm_npv, norm_bs and date
+    )  # bs, npv, pc_missing, pv, water, wet, date, feature_id, norm_pv, norm_npv, norm_bs
 
 
 def test_wit_single_file_stacking(tmp_path):


### PR DESCRIPTION
We should use `index=False`, not `index_label=False`. Fix that typo.