### PR TITLE
Update wofs bitmask for low solar angle

### DIFF
--- a/examples/wit_ls5.conflux.py
+++ b/examples/wit_ls5.conflux.py
@@ -63,7 +63,7 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
     output_rast["pv"] = pv
     output_rast["npv"] = npv
 
-    mask = (wo_ds.water & 0b01100011) == 0
+    mask = (wo_ds.water & 0b01100111) == 0
     # not apply poly_raster cause we will do it before summarise
 
     open_water = wo_ds.water & (1 << 7) > 0

--- a/examples/wit_ls7.conflux.py
+++ b/examples/wit_ls7.conflux.py
@@ -63,7 +63,7 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
     output_rast["pv"] = pv
     output_rast["npv"] = npv
 
-    mask = (wo_ds.water & 0b01100011) == 0
+    mask = (wo_ds.water & 0b01100111) == 0
     # not apply poly_raster cause we will do it before summarise
 
     open_water = wo_ds.water & (1 << 7) > 0

--- a/examples/wit_ls8.conflux.py
+++ b/examples/wit_ls8.conflux.py
@@ -63,7 +63,7 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
     output_rast["pv"] = pv
     output_rast["npv"] = npv
 
-    mask = (wo_ds.water & 0b01100011) == 0
+    mask = (wo_ds.water & 0b01100111) == 0
     # not apply poly_raster cause we will do it before summarise
 
     open_water = wo_ds.water & (1 << 7) > 0

--- a/examples/wit_ls9.conflux.py
+++ b/examples/wit_ls9.conflux.py
@@ -69,7 +69,7 @@ def transform(inputs: xr.Dataset) -> xr.Dataset:
 
     # Mask noncontiguous data, low solar incidence angle, cloud, and water out of the wet category
     # by disabling those flags
-    mask = (wo_ds.water & 0b01100011) == 0
+    mask = (wo_ds.water & 0b01100111) == 0
     # not apply poly_raster cause we will do it before summarise
 
     open_water = wo_ds.water & (1 << 7) > 0


### PR DESCRIPTION
Shane's note:

> 2. Use the Water Observations bit flags to mask non-contiguous data, low solar incidence angle, cloud, and water out of the `wet` category. 

# Mask includes No data, Non contiguous data, Cloud shadow, Cloud, and water.
mask = (ds_wo.water & 0b01100011) == 0

If I am reading  https://knowledge.dea.ga.gov.au/notebooks/DEA_products/DEA_Water_Observations/#Understanding-WOs-bit-flags correctly  then bit 2 = Low solar angle

so to include low solar incidence angle the bitmask would be   0b01100111