### PR TITLE
geohash_wetland_id field added

### DIFF
--- a/dea_conflux/drill.py
+++ b/dea_conflux/drill.py
@@ -15,6 +15,7 @@ from types import ModuleType
 from typing import Union
 
 import datacube
+import geohash
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -692,6 +693,19 @@ def drill(
     summary_df = pd.DataFrame(
         {one_index_to_id[int(k)]: summaries[k] for k in summaries}
     ).T
+
+    # Add geohash_wetland_id for WIT plugins.
+    if hasattr(plugin, "product_name") and plugin.product_name.startswith("wit_"):
+        result_ids = summary_df.index
+        present = shapefile.loc[shapefile.index.isin(result_ids)]
+        centroids_projected = present.geometry.centroid
+        centroids_4326 = (
+            gpd.GeoSeries(centroids_projected, crs=shapefile.crs)
+            .to_crs(epsg=4326)
+        )
+        summary_df["geohash_wetland_id"] = [
+            geohash.encode(c.y, c.x, precision=12) for c in centroids_4326
+        ]
 
     # Merge in the edge information.
     if partial and not overedge:


### PR DESCRIPTION
This change adds a geohash_wetland_id field to the output (parquet and CSV) when dea-conflux is run with a wit plugin.

<img width="950" height="149" alt="image" src="https://github.com/user-attachments/assets/5d537848-1ff9-4e30-ab0c-45f5ad765a19" />
<img width="950" height="149" alt="image" src="https://github.com/user-attachments/assets/5d537848-1ff9-4e30-ab0c-45f5ad765a19" />
